### PR TITLE
Fix minor syntactic issue in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can also customize the output by supplying your own format blocks:
         return nil;
     }
 
-    return [NSString stringWithFormat:"%@ %@", [operation.request HTTPMethod], [[operation.request URL] absoluteString]];
+    return [NSString stringWithFormat:@"%@ %@", [operation.request HTTPMethod], [[operation.request URL] absoluteString]];
 }];
 ```
 


### PR DESCRIPTION
Noticed the format string in the example was missing the @ prefix.
